### PR TITLE
fix: force detail card to render with unique key

### DIFF
--- a/frontend/src/components/KanbanDetail.vue
+++ b/frontend/src/components/KanbanDetail.vue
@@ -76,7 +76,7 @@ export default Vue.extend({
       selectedpersonaids: [],
       estimateOptions: [1, 2, 3, 5, 8, 13, 21],
       skipQuery: true,
-      thisID: this.id,
+      currentItemId: this.id,
     };
   },
   created() {
@@ -85,7 +85,9 @@ export default Vue.extend({
       console.log('newitem');
       this.skipQuery = true;
       this.createNewItem();
+      this.currentItemId = this.id;
     } else {
+      this.currentItemId = this.id;
       this.skipQuery = false;
     }
   },
@@ -123,12 +125,12 @@ export default Vue.extend({
       // Static parameters
       variables() {
         return {
-          itemid: this.id,
+          itemid: this.currentItemId,
         };
       },
       // Disable the query when waiting for a new item id
       skip() {
-        return this.id === 'newitem';
+        return this.currentItemId === 'newitem';
       },
     },
   },
@@ -149,7 +151,7 @@ export default Vue.extend({
           `,
           // Parameters
           variables: {
-            id: this.id,
+            id: this.currentItemId,
           },
         })
         .then((data) => {
@@ -203,7 +205,7 @@ export default Vue.extend({
           `,
           // Parameters
           variables: {
-            id: this.id,
+            id: this.currentItemId,
             title: this.itemById.title,
             estimate: this.itemById.estimate,
             description: this.itemById.description,
@@ -314,7 +316,7 @@ export default Vue.extend({
         .then((data) => {
           // Result
           console.log('generated new id:' + data.data.createItem.id);
-          this.thisId = data.data.createItem.id;
+          this.currentItemId = data.data.createItem.id;
           this.itemById = data.data.createItem;
           this.skipQuery = false;
         })

--- a/frontend/src/components/KanbanView.vue
+++ b/frontend/src/components/KanbanView.vue
@@ -44,7 +44,7 @@
     </kanban-board>
     <v-dialog v-model="dialog" max-width="80%">
       <v-card>
-        <KanbanDetail v-bind:id="id" v-on:item-deleted="dialog = false" />
+        <KanbanDetail v-bind:id="id" v-on:item-deleted="dialog = false" :key="id" />
       </v-card>
     </v-dialog>
   </v-img>


### PR DESCRIPTION
Fix to force detail cards to re-render with clicked item - they were previously not refreshing and only loading the first card clicked.