### PR TITLE
feat: NestJS config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,6 +13,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    services:
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
 
     strategy:
       matrix:
@@ -38,7 +43,11 @@ jobs:
         cd frontend
         yarn
         # yarn test
-    - name: Backend tests
+    - name: Backend unit tests
       run: |
         cd backend
         yarn test
+    - name: Backend e2e tests
+      run: |
+        cd backend
+        yarn test:e2e

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,6 +38,7 @@ const newRelicPlugin = require('@newrelic/apollo-server-plugin')
     AuthModule,
     ConfigModule.forRoot({
       isGlobal: true,
+      envFilePath: ['.env', 'test.env', 'local.dev.env', 'dev.env'],
     }),
   ],
   controllers: [HealthController],

--- a/backend/test.env
+++ b/backend/test.env
@@ -3,3 +3,5 @@ AUTH0_AUDIENCE=https://your.domin
 MONGO_CONNECTION='mongodb://localhost:27017'
 NEW_RELIC_ENABLED=false
 NEW_RELIC_NO_CONFIG_FILE=true
+RECAP_DEV_ENABLED=false
+RECAP_DEV_SYNC_ENDPOINT='schema://hostname:port/traces'

--- a/backend/test/auth.helpers.ts
+++ b/backend/test/auth.helpers.ts
@@ -7,13 +7,13 @@ export function startAuthServer(jwksServer: string): JWKSMock {
     return jwks;
 }
 
-export function getToken(jwks: JWKSMock): string {
+export function getToken(jwks: JWKSMock, authDomain: string, authAudience: string): string {
     const token = jwks.token({
         aud: [
-            "https://catkin.dev",
-            "https://catkin-dev.eu.auth0.com/userinfo"
+            `${authAudience}`,
+            `${authDomain}/userinfo`
         ],
-        iss: `https://catkin-dev.eu.auth0.com/`,
+        iss: `${authDomain}/`,
         'https://catkin.dev/permissions': [
             {
                 "group": "*",

--- a/backend/test/e2e/setup.ts
+++ b/backend/test/e2e/setup.ts
@@ -7,6 +7,7 @@ import { AppModule } from '../../src/app.module';
 import createJWKSMock, { JWKSMock } from 'mock-jwks';
 import JwksRsa from 'jwks-rsa';
 import { getToken, startAuthServer } from '../auth.helpers';
+import { ConfigService } from '@nestjs/config';
 
 
 declare global {
@@ -21,6 +22,7 @@ declare global {
 export default global;
 
 beforeAll(async () => {
+  
   try {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
@@ -30,14 +32,15 @@ beforeAll(async () => {
 
     await global.app.init();
     console.log('NestJS server started for e2e tests');
+    const configService = global.app.get(ConfigService);
+    const authDomain = configService.get('AUTH0_DOMAIN');
+    const authAudience = configService.get('AUTH0_AUDIENCE');
 
-    global.jwks = startAuthServer("https://catkin-dev.eu.auth0.com");
+    global.jwks = startAuthServer(authDomain);
     console.log('Mock Auth0 server started for e2e tests');
 
-    global.validAuthToken = getToken(global.jwks);
+    global.validAuthToken = getToken(global.jwks, authDomain, authAudience);
     console.log('Mock Auth0 token generated for e2e tests');
-
-
 
     // await global.app.getHttpAdapter().getInstance().ready();
   } catch (e) {


### PR DESCRIPTION
- Use NestJS config service within tests to get auth settings (previously hard coded)
- Read multiple config files including test.env for CI environment
- Tests now work straight away in Gitpod with no additional config
- Startup mongo DB in CI workflow and run backend e2e tests